### PR TITLE
RateManager fixed using Debugger instead of RateDebug inside a !UNITY_2019_3_OR_NEWER preprocessing directive

### DIFF
--- a/Runtime/RateManager.cs
+++ b/Runtime/RateManager.cs
@@ -777,8 +777,8 @@ namespace UniRate {
         private void LogRenderIntervalNotSupportedOnce() {
             if (this._loggedRenderIntervalNotSupported) return;
             this._loggedRenderIntervalNotSupported = true;
-            if (Debugger.IsLogLevelActive(LogLevel.Warning)) {
-                Debugger.Log(LogLevel.Warning, $"render interval is only supported on Unity 2019.3 or newer");
+            if (RateDebug.IsLogLevelActive(RateLogLevel.Warning)) {
+                RateDebug.Log(RateLogLevel.Warning, $"render interval is only supported on Unity 2019.3 or newer");
             }
         }
         


### PR DESCRIPTION
This was causing errors when imported on Unity version < 2019 
(tested in Unity 2018.4.35f1)